### PR TITLE
Integration Tests Lifecycle and travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+before_script:
+  - cd ./server/ && bundle install
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk8
+  - openjdk7
+  - openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+test:
+  - mvn clean install
 before_script:
   - cd ./server/ && bundle install
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
-test:
-  - mvn verify
 before_script:
   - cd ./server/ && bundle install
+script:
+  - mvn verify
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 before_script:
-  - cd ./server/ && bundle install
+  - cd ./server/ && bundle install && cd ..
 script:
   - mvn verify
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: java
 test:
-  - mvn clean install
+  - mvn verify
 before_script:
   - cd ./server/ && bundle install
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - openjdk8
   - openjdk7
   - openjdk6

--- a/README.md
+++ b/README.md
@@ -107,11 +107,19 @@ The dependencies are managed via Maven.
 * Write your code and **test it**;
 * Make a pull request.
 
-Please use TDD. In order to test, you will need to run the the fake web service
-within the `server` directory like this:
+Please use TDD. In order to test, you will need to install [ruby][1], [bundler][2]
+and [sinatra][3]. To install sinatra, with ruby and bundler already installed,
+run:
 
-```
-ruby server/fake_server.rb
+```sh
+cd server
+bundle install
 ```
 
-This fake server is built on [Sinatra](http://www.sinatrarb.com/).
+The integrations tests will run the server in the `integration-test` phase
+and shut it down when tests are done. Right now, it only works in *nix
+systems but pull-requests are accepted.
+
+[1]: https://www.ruby-lang.org
+[2]: http://bundler.io/
+[3]: http://www.sinatrarb.com/

--- a/README.md
+++ b/README.md
@@ -107,17 +107,17 @@ The dependencies are managed via Maven.
 * Write your code and **test it**;
 * Make a pull request.
 
-Please use TDD. In order to test, you will need to install [ruby][1], [bundler][2]
-and [sinatra][3]. To install sinatra, with ruby and bundler already installed,
-run:
+Please use TDD. In order to test, you will need to install [Ruby][1], [Bundler][2]
+and [Sinatra][3] . To install Sinatra (and any other needed rubygems),
+with Ruby and Bundler already installed, run:
 
 ```sh
 cd server
 bundle install
 ```
 
-The integrations tests will run the server in the `integration-test` phase
-and shut it down when tests are done. Right now, it only works in *nix
+The integrations tests will run the server in the `pre-integration-test` phase
+and shut it down in `post-integration-test`. Right now, it only works in *nix
 systems but pull-requests are accepted.
 
 [1]: https://www.ruby-lang.org

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,74 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.6</version>
+				<executions>
+					<execution>
+						<id>pre-it</id>
+						<!-- runs the fake_server before integration-tests phase -->
+						<phase>pre-integration-test</phase>
+						<configuration>
+							<target>
+								<exec executable="ruby" spawn="true">
+									<arg value="./server/fake_server.rb" />
+								</exec>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-it</id>
+						<!-- kills fake server after integration tests are finished -->
+						<phase>post-integration-test</phase>
+						<configuration>
+							<target>
+								<exec executable="sh">
+									<arg value="-c" />
+									<arg value=" ps ax | grep -i 'ruby' | grep fake_server | grep -v grep | awk '{print $1}' | xargs kill -SIGTERM" />
+								</exec>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<!--
+					configures the includes and excludes patterns for tests
+					and integration-tests
+				-->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>**/*IntegrationTest.java</exclude>
+					</excludes>
+				</configuration>
+				<executions>
+					<execution>
+						<id>integration-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<phase>integration-test</phase>
+						<configuration>
+							<excludes>
+								<exclude>none</exclude>
+							</excludes>
+							<includes>
+								<include>**/*IntegrationTest.java</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
-
 	</build>
 	<dependencies>
 		<dependency>
@@ -28,6 +94,5 @@
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -1,6 +1,3 @@
 source 'https://rubygems.org'
-
-ruby '2.1.0'
-
 gem 'sinatra'
 

--- a/src/test/java/restresource/RestResourceIntegrationTest.java
+++ b/src/test/java/restresource/RestResourceIntegrationTest.java
@@ -19,7 +19,7 @@ import restresource.support.Person;
 import restresource.support.StatusCode;
 import restresource.utils.Proc;
 
-public class RestResourceTest {
+public class RestResourceIntegrationTest {
 	@Test
 	public void testFind() {
 		Person p = RestResource.find(1, Person.class);


### PR DESCRIPTION
Now integrations tests will start the `fake_server` without any further
user interaction.

I also defined a pattern for Integration Tests
(`*IntegrationsTest.java`), so, any class inside `test` folder which
follow this pattern will be executed in the right phase.

I also added the `.travis.yml` file, but didn't tested it because travis
seems to refuse to run in forks. I did ran `travin-lint` on it tough, and
seems to be ok. You can go to travis-ci.org and enable it if you want :beers: 
